### PR TITLE
Update new range of analog PinA0

### DIFF
--- a/Arduino code/Temperature/temperature.ino
+++ b/Arduino code/Temperature/temperature.ino
@@ -1,7 +1,6 @@
-
 float PinA0 = 0; /* range from 0 to 1023 */
-                 /* voltage generate from 0 - 5v */
-                 /* so 1 voltage = 0.2046 (range of output) */
+                 /* voltage generate from 0 - 3.3v for Udoo Neo */
+                 /* so 1 voltage = 0.31 (range of output) */
 float Vout = 0;
 float Temp = 0;
 
@@ -13,7 +12,7 @@ void setup()
 void loop()
 {
   PinA0 = analogRead(A0);
-  Vout = PinA0 / 0.2046;
+  Vout = PinA0 / 0.31;
   
   Temp = (Vout - 2098.84)/-10.817; /* range of temperature -10¤C to 50¤C */
                                    /* Caculated by equation V - V1 = (V2-V1)/(T2-T1)*(T-T1)  */


### PR DESCRIPTION
The old version with A0 input range from 0 - 5V has been replace by 0 - 3.3V due to the difference between Udoo Neo and Arduino.